### PR TITLE
Adding process.on hack example

### DIFF
--- a/test/fixtures/log.js
+++ b/test/fixtures/log.js
@@ -20,6 +20,9 @@ for (var i = 0; i < max; i++) {
 }
 
 exit(errorCode);
+process.on('exit', function() { 
+  exit(errorCode) 
+})
 
 stdout('fail');
 stderr('fail');


### PR DESCRIPTION
This passes on exit codes tests on Windows, can we wrap it in a better way?
