### PR TITLE
Updated exit.js to use callback from empty write instead of drain event

### DIFF
--- a/lib/exit.js
+++ b/lib/exit.js
@@ -19,7 +19,7 @@ module.exports = function exit(exitCode, streams) {
   }
   streams.forEach(function(stream) {
     // Count drained streams now, but monitor non-drained streams.
-    if (stream.bufferSize === 0){
+    if (stream.bufferSize === 0) {
       drainCount++;
     } else {
       stream.write('', 'utf-8', function() {

--- a/lib/exit.js
+++ b/lib/exit.js
@@ -18,17 +18,17 @@ module.exports = function exit(exitCode, streams) {
     }
   }
   streams.forEach(function(stream) {
-    // Prevent further writing.
-    stream.write = function() {};
     // Count drained streams now, but monitor non-drained streams.
-    if (stream.bufferSize === 0) {
+    if(stream.bufferSize === 0){
       drainCount++;
     } else {
-      stream.once('drain', function() {
+      stream.write('', 'utf-8', function() {
         drainCount++;
         tryToExit();
       });
     }
+    // Prevent further writing.
+    stream.write = function() {};
   });
   // If all streams were already drained, exit now.
   tryToExit();

--- a/lib/exit.js
+++ b/lib/exit.js
@@ -19,7 +19,7 @@ module.exports = function exit(exitCode, streams) {
   }
   streams.forEach(function(stream) {
     // Count drained streams now, but monitor non-drained streams.
-    if(stream.bufferSize === 0){
+    if (stream.bufferSize === 0){
       drainCount++;
     } else {
       stream.write('', 'utf-8', function() {


### PR DESCRIPTION
This commit fixes #4

Fix was tested in Windows 7 and 8 in cmd, powershell, and git-bash.

I also tested the original issue with a hanging build on TeamCity and the full test was reported without hanging.
