### PR TITLE
allow process.exit to be replaced

### DIFF
--- a/lib/exit.js
+++ b/lib/exit.js
@@ -8,13 +8,15 @@
 
 'use strict';
 
-module.exports = function exit(exitCode, streams) {
+module.exports = function exit(exitCode, streams, exitFn) {
   if (!streams) { streams = [process.stdout, process.stderr]; }
+  if (!exitFn) { exitFn = process.exit; }
+  
   var drainCount = 0;
   // Actually exit if all streams are drained.
   function tryToExit() {
     if (drainCount === streams.length) {
-      process.exit(exitCode);
+      exitFn(exitCode);
     }
   }
   streams.forEach(function(stream) {
@@ -36,6 +38,6 @@ module.exports = function exit(exitCode, streams) {
   // this library might just exit with a 0 exit code, regardless. This code,
   // despite the fact that it looks a bit crazy, appears to fix that.
   process.on('exit', function() {
-    process.exit(exitCode);
+    exitFn(exitCode);
   });
 };


### PR DESCRIPTION
If application is using a module that calls process.exit then only way to hook up node-exit is to globally override process.exit and call exit() of node-exit but if it internally calls process.exit again then it will result in infinite recursion. To overcome this issue, we should be able to pass custom process.exit function (the original unoverriden) for use by node-exit
